### PR TITLE
Avoiding type errors

### DIFF
--- a/web/src/app/app.component.ts
+++ b/web/src/app/app.component.ts
@@ -4,6 +4,7 @@ import { Proxy } from 'braid-client';
 // NOTE: I'm not too familiar with the more recent versions of angular
 // the following should probably go somewhere else!
 
+declare var window: any;
 const proxy = new Proxy({url: 'http://localhost:8081/api/'}, onOpen, onClose, onError, {strictSSL: false})
 
 function onOpen() {


### PR DESCRIPTION
Without these changes it won't compile:
`ERROR in src/app/app.component.ts(14,10): error TS2339: Property 'proxy' does not exist on type 'Window'.`